### PR TITLE
Fix: Ajouter filterSections manquant dans mapboxListingsStore

### DIFF
--- a/app/_components/layout/FilterSection.jsx
+++ b/app/_components/layout/FilterSection.jsx
@@ -18,6 +18,7 @@ import {
 import {
   useFiltersState,
   useFiltersActions,
+  filterSections,
 } from "@/lib/store/mapboxListingsStore";
 import { useSearchParams } from "next/navigation";
 import { useUpdateExploreUrl } from "@/utils/updateExploreUrl";
@@ -28,69 +29,6 @@ export const openMobileFilters = () => {
     window.dispatchEvent(new CustomEvent("openMobileFilters"));
   }
 };
-
-/* -------- filter sections -------- */
-export const filterSections = [
-  {
-    title: "Produits",
-    key: "product_type",
-    items: [
-      "Fruits",
-      "Légumes",
-      "Produits laitiers",
-      "Viande",
-      "Œufs",
-      "Produits transformés",
-    ],
-  },
-  {
-    title: "Certifications",
-    key: "certifications",
-    items: ["Label AB", "Label Rouge", "AOP/AOC", "HVE", "Demeter"],
-  },
-  {
-    title: "Distribution",
-    key: "purchase_mode",
-    items: [
-      "Vente directe à la ferme",
-      "Marché local",
-      "Livraison à domicile",
-      "Drive fermier",
-    ],
-  },
-  {
-    title: "Production",
-    key: "production_method",
-    items: [
-      "Agriculture conventionnelle",
-      "Agriculture biologique",
-      "Agriculture durable",
-      "Agriculture raisonnée",
-    ],
-  },
-  {
-    title: "Services",
-    key: "additional_services",
-    items: [
-      "Visite de la ferme",
-      "Ateliers de cuisine",
-      "Hébergement",
-      "Activités pour enfants",
-      "Réservation pour événements",
-    ],
-  },
-  {
-    title: "Disponibilité",
-    key: "availability",
-    items: [
-      "Saisonnière",
-      "Toute l'année",
-      "Pré-commande",
-      "Sur abonnement",
-      "Événements spéciaux",
-    ],
-  },
-];
 
 const mapFilterTypes = [
   { id: "conventional", label: "Agriculture conventionnelle" },

--- a/lib/store/mapboxListingsStore.js
+++ b/lib/store/mapboxListingsStore.js
@@ -5,7 +5,68 @@ import { immer } from "zustand/middleware/immer";
 import { supabase } from "@/utils/supabase/client";
 import { toast } from "sonner";
 
-/* ... MAPBOX_CONFIG, MAP_STYLES, filterSections inchangés ... */
+// Types de filtres disponibles
+export const filterSections = [
+  {
+    title: "Produits",
+    key: "product_type",
+    items: [
+      "Fruits",
+      "Légumes",
+      "Produits laitiers",
+      "Viande",
+      "Œufs",
+      "Produits transformés",
+    ],
+  },
+  {
+    title: "Certifications",
+    key: "certifications",
+    items: ["Label AB", "Label Rouge", "AOP/AOC", "HVE", "Demeter"],
+  },
+  {
+    title: "Distribution",
+    key: "purchase_mode",
+    items: [
+      "Vente directe à la ferme",
+      "Marché local",
+      "Livraison à domicile",
+      "Drive fermier",
+    ],
+  },
+  {
+    title: "Production",
+    key: "production_method",
+    items: [
+      "Agriculture conventionnelle",
+      "Agriculture biologique",
+      "Agriculture durable",
+      "Agriculture raisonnée",
+    ],
+  },
+  {
+    title: "Services",
+    key: "additional_services",
+    items: [
+      "Visite de la ferme",
+      "Ateliers de cuisine",
+      "Hébergement",
+      "Activités pour enfants",
+      "Réservation pour événements",
+    ],
+  },
+  {
+    title: "Disponibilité",
+    key: "availability",
+    items: [
+      "Saisonnière",
+      "Toute l'année",
+      "Pré-commande",
+      "Sur abonnement",
+      "Événements spéciaux",
+    ],
+  },
+];
 
 // Helpers init sûrs
 const makeInitialFilters = () => {


### PR DESCRIPTION
Le store mapboxListingsStore utilisait la variable filterSections sans la définir, ce qui causait une ReferenceError et empêchait l'initialisation du store. Cela rendait les filtres non-fonctionnels.

Changements:
- Ajout de la définition complète de filterSections dans mapboxListingsStore.js
- Import de filterSections depuis le store dans FilterSection.jsx pour éviter la duplication de code
- Suppression de la définition redondante dans FilterSection.jsx

Résout le problème où les clics sur les filtres ne fonctionnaient pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)