### PR TITLE
feat(search): persist landing→explore search, add recent searches, al…

### DIFF
--- a/app/_components/layout/FilterSection/FilterSection.tsx
+++ b/app/_components/layout/FilterSection/FilterSection.tsx
@@ -137,8 +137,8 @@ const FilterSection: React.FC<FilterSectionProps> = ({ className = "" }) => {
   return (
     <div className={`flex w-full flex-col gap-1 ${className}`}>
       {/* Barre de filtres principale */}
-      <div className="w-full border-b border-gray-100 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-        <div className="mx-auto max-w-6xl px-3">
+      <div className="w-full border-b border-gray-100 bg-white">
+        <div className="mx-auto max-w-6xl px-4">
           <div className="no-scrollbar flex h-12 items-center gap-2 overflow-x-auto py-2 [scrollbar-width:none] [-ms-overflow-style:none]">
             {/* ═══ Filtres dynamiques depuis la config ═══ */}
             {memoizedFilterSections.map((section: any, index: number) => {
@@ -281,7 +281,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({ className = "" }) => {
             <button
               type="button"
               onClick={() => setIsModalOpen(true)}
-              className="ml-auto inline-flex h-9 items-center gap-2 rounded-full border border-gray-200 bg-white px-3 text-xs shadow-[0_1px_0_0_rgba(17,24,39,0.04)] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              className="ml-auto inline-flex h-9 items-center gap-2 rounded-full border border-gray-200 bg-white px-3 text-xs shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500"
               aria-label="Ouvrir le panneau de filtres avancés"
             >
               <Filter className="h-4 w-4" />

--- a/app/_components/layout/FilterSection/components/DropdownPill.tsx
+++ b/app/_components/layout/FilterSection/components/DropdownPill.tsx
@@ -178,7 +178,7 @@ const DropdownPill: React.FC<DropdownPillProps> = ({
         e.stopPropagation();
         toggle();
       }}
-      className={`inline-flex h-9 items-center gap-2 rounded-full border px-3 text-xs shadow-[0_1px_0_0_rgba(17,24,39,0.04)] transition ${CSS_CLASSES.FOCUS_RING} ${
+      className={`inline-flex h-9 items-center gap-2 rounded-full border px-3 text-xs shadow-sm transition ${CSS_CLASSES.FOCUS_RING} ${
         disabled
           ? "border-gray-200 bg-gray-100 text-gray-400 cursor-not-allowed"
           : isActive

--- a/app/modules/maps/components/shared/MapboxCitySearch.tsx
+++ b/app/modules/maps/components/shared/MapboxCitySearch.tsx
@@ -90,6 +90,14 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
   const abortControllerRef = useRef<AbortController | null>(null);
   const suppressNextSearchRef = useRef<boolean>(false);
 
+  // Hooks Next.js — declared before state so urlParams is available for lazy init
+  const router = useRouter();
+  const pathname = usePathname();
+  const urlParams = useSearchParams();
+
+  // Recent searches (localStorage)
+  const { recentSearches, addRecentSearch } = useRecentSearches();
+
   // États
   const cityFromUrl = variant === "header" ? (urlParams?.get("city") ?? "") : "";
   const [searchText, setSearchText] = useState<string>(cityFromUrl);
@@ -97,14 +105,6 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [showSuggestions, setShowSuggestions] = useState<boolean>(false);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
-
-  // Hooks Next.js
-  const router = useRouter();
-  const pathname = usePathname();
-  const urlParams = useSearchParams();
-
-  // Recent searches (localStorage)
-  const { recentSearches, addRecentSearch } = useRecentSearches();
 
   /**
    * Recherche Mapbox

--- a/app/modules/maps/components/shared/MapboxCitySearch.tsx
+++ b/app/modules/maps/components/shared/MapboxCitySearch.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import React, { useRef, useState, useCallback, useEffect } from "react";
-import { Search, MapPin } from "lucide-react";
+import { Search, MapPin, Clock } from "lucide-react";
 import { toast } from "sonner";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { COLORS } from "@/lib/config";
 import { logger } from "@/lib/logger";
+import { useRecentSearches } from "../../hooks/useRecentSearches";
 
 /**
  * Interfaces TypeScript pour MapboxCitySearch
@@ -90,7 +91,8 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
   const suppressNextSearchRef = useRef<boolean>(false);
 
   // États
-  const [searchText, setSearchText] = useState<string>("");
+  const cityFromUrl = variant === "header" ? (urlParams?.get("city") ?? "") : "";
+  const [searchText, setSearchText] = useState<string>(cityFromUrl);
   const [suggestions, setSuggestions] = useState<CitySearchResult[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [showSuggestions, setShowSuggestions] = useState<boolean>(false);
@@ -100,6 +102,9 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
   const router = useRouter();
   const pathname = usePathname();
   const urlParams = useSearchParams();
+
+  // Recent searches (localStorage)
+  const { recentSearches, addRecentSearch } = useRecentSearches();
 
   /**
    * Recherche Mapbox
@@ -246,7 +251,6 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
         window.setTimeout(() => {
           setShowSuggestions(false);
           setSuggestions([]);
-          if (variant === "header") setSearchText("");
         }, 100);
 
         logger.debug("MapboxCitySearch: navigation", {
@@ -277,6 +281,13 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
 
         const cityData: CitySearchResult = { ...suggestion, zoom: 12 };
         onCitySelect?.(cityData);
+
+        addRecentSearch({
+          city: suggestion.text,
+          place_name: suggestion.place_name,
+          center: suggestion.center,
+          bbox: suggestion.bbox,
+        });
 
         navigateWith(suggestion);
 
@@ -382,14 +393,19 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
   }, []);
 
   /**
-   * Reset lors changements URL
+   * Reset lors changements URL — syncs header search text from city param
    */
   const paramsString = urlParams?.toString() || "";
   useEffect(() => {
     setShowSuggestions(false);
     setSuggestions([]);
     suppressNextSearchRef.current = false;
-  }, [pathname, paramsString]);
+    if (variant === "header") {
+      // Suppress the debounce search triggered by this programmatic text change
+      suppressNextSearchRef.current = true;
+      setSearchText(urlParams?.get("city") ?? "");
+    }
+  }, [pathname, paramsString, variant, urlParams]);
 
   /**
    * Clear
@@ -448,13 +464,18 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
             setSearchText(e.target.value);
             if (!e.target.value.trim()) {
               setSuggestions([]);
-              setShowSuggestions(false);
+              // Show recent searches panel if available
+              setShowSuggestions(recentSearches.length > 0);
             } else {
               setShowSuggestions(true);
             }
           }}
           onKeyDown={handleKeyDown}
-          onFocus={() => suggestions.length > 0 && setShowSuggestions(true)}
+          onFocus={() => {
+            if (suggestions.length > 0 || (recentSearches.length > 0 && searchText.length < 3)) {
+              setShowSuggestions(true);
+            }
+          }}
           placeholder={placeholder}
           className="flex-grow bg-transparent outline-none text-sm"
           style={{ color: COLORS.TEXT_PRIMARY }}
@@ -516,6 +537,63 @@ const MapboxCitySearch: React.FC<MapboxCitySearchProps> = ({
           </button>
         )}
       </div>
+
+      {/* Recent Searches — shown when focused and text < 3 chars */}
+      {showSuggestions && recentSearches.length > 0 && searchText.length < 3 && (
+        <div
+          ref={suggestionsRef}
+          className="absolute top-full left-0 right-0 mt-2 rounded-xl shadow-xl z-[9999] max-h-80 overflow-y-auto"
+          style={{
+            backgroundColor: COLORS.BG_WHITE,
+            border: `1px solid ${COLORS.BORDER}`,
+          }}
+        >
+          <div
+            className="px-4 py-2 text-xs font-medium border-b"
+            style={{ color: COLORS.TEXT_MUTED, borderColor: COLORS.BORDER }}
+          >
+            Recherches récentes
+          </div>
+          {recentSearches.map((recent, index) => (
+            <button
+              key={`recent-${index}-${recent.city}`}
+              onClick={() =>
+                selectSuggestion({
+                  id: `recent-${index}`,
+                  text: recent.city,
+                  place_name: recent.place_name,
+                  center: recent.center,
+                  bbox: recent.bbox,
+                })
+              }
+              className="w-full text-left px-4 py-3 transition-colors border-b last:border-b-0 first:rounded-t-xl last:rounded-b-xl hover:bg-gray-50"
+              style={{ borderColor: COLORS.BORDER }}
+              type="button"
+            >
+              <div className="flex items-start gap-3">
+                <Clock
+                  className="w-4 h-4 mt-0.5 flex-shrink-0"
+                  style={{ color: COLORS.TEXT_MUTED }}
+                />
+                <div className="flex-grow min-w-0">
+                  <div
+                    className="font-medium truncate text-sm"
+                    style={{ color: COLORS.TEXT_PRIMARY }}
+                  >
+                    {recent.city}
+                  </div>
+                  <div
+                    className="text-xs truncate"
+                    style={{ color: COLORS.TEXT_SECONDARY }}
+                  >
+                    {recent.place_name}
+                  </div>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Suggestions */}
       {showSuggestions && suggestions.length > 0 && (

--- a/app/modules/maps/hooks/useRecentSearches.ts
+++ b/app/modules/maps/hooks/useRecentSearches.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_KEY = "farm2fork_recent_searches";
+const MAX_ENTRIES = 6;
+
+export interface RecentSearch {
+  city: string;
+  place_name: string;
+  center: [number, number];
+  bbox?: [number, number, number, number];
+}
+
+export function useRecentSearches() {
+  const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
+
+  // Hydrate from localStorage on mount (client-only)
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as RecentSearch[];
+        if (Array.isArray(parsed)) setRecentSearches(parsed);
+      }
+    } catch {
+      // Ignore parse errors or missing localStorage (SSR, private browsing)
+    }
+  }, []);
+
+  const addRecentSearch = useCallback((entry: RecentSearch) => {
+    setRecentSearches((prev) => {
+      // Deduplicate by city name (case-insensitive)
+      const deduped = prev.filter(
+        (r) => r.city.toLowerCase() !== entry.city.toLowerCase()
+      );
+      // Most recent first, capped at MAX_ENTRIES
+      const next = [entry, ...deduped].slice(0, MAX_ENTRIES);
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        // Ignore storage quota errors
+      }
+      return next;
+    });
+  }, []);
+
+  return { recentSearches, addRecentSearch };
+}

--- a/app/modules/maps/hooks/useRecentSearches.ts
+++ b/app/modules/maps/hooks/useRecentSearches.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 
 const STORAGE_KEY = "farm2fork_recent_searches";
 const MAX_ENTRIES = 6;
@@ -12,21 +12,22 @@ export interface RecentSearch {
   bbox?: [number, number, number, number];
 }
 
-export function useRecentSearches() {
-  const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
-
-  // Hydrate from localStorage on mount (client-only)
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as RecentSearch[];
-        if (Array.isArray(parsed)) setRecentSearches(parsed);
-      }
-    } catch {
-      // Ignore parse errors or missing localStorage (SSR, private browsing)
+function readRecentSearches(): RecentSearch[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as RecentSearch[];
+      if (Array.isArray(parsed)) return parsed;
     }
-  }, []);
+  } catch {
+    // Ignore parse errors or missing localStorage (private browsing)
+  }
+  return [];
+}
+
+export function useRecentSearches() {
+  const [recentSearches, setRecentSearches] = useState<RecentSearch[]>(readRecentSearches);
 
   const addRecentSearch = useCallback((entry: RecentSearch) => {
     setRecentSearches((prev) => {


### PR DESCRIPTION
…ign filters

- MapboxCitySearch (header variant) now initializes searchText from the city URL param on mount and re-syncs on every URL change, so the search field stays populated after landing→/explore navigation and on refresh
- Removed the post-navigation setSearchText("") clear that was causing the header input to go blank after city selection
- Add useRecentSearches hook: localStorage-backed, max 6 entries, deduplicated by city name, most recent first (key: farm2fork_recent_searches)
- MapboxCitySearch shows a Recent Searches panel when focused with < 3 chars; each city selection is saved to the history
- FilterSection: bg-white/80 backdrop-blur → bg-white to match header; px-3 → px-4 for consistent spacing; Filtres button shadow-sm
- DropdownPill: custom 1px shadow → shadow-sm for consistent visual weight

https://claude.ai/code/session_016WjHUUSTuPaFMLkRuPUaXm