### PR TITLE
fix(map): react to store coordinate changes regardless of animation s…

### DIFF
--- a/app/modules/maps/components/MapboxSection.tsx
+++ b/app/modules/maps/components/MapboxSection.tsx
@@ -299,7 +299,7 @@ export default function MapboxSection({
       };
 
       const handleMoveStart = (e?: any) => {
-        if (e && (e.originalEvent || e.type)) userInteractingRef.current = true;
+        if (e?.originalEvent) userInteractingRef.current = true;
       };
 
       const handleMoveEnd = () => {
@@ -375,7 +375,6 @@ export default function MapboxSection({
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !isApiLoaded) return;
-    if (userInteractingRef.current) return;
     if (!isValidCoords(coordinates)) return;
 
     const mapboxCoords = coordsToMapbox(coordinates);


### PR DESCRIPTION
…tate

handleMoveStart set userInteractingRef=true for all map movements including programmatic easeTo calls, because e.type ("movestart") is always truthy. This blocked the sync effect whenever a city search fired during or shortly after a programmatic animation, causing the map to never reach the new city.

Two changes:
- handleMoveStart now only sets the flag when e.originalEvent is present (real user interactions: drag, scroll, touch)
- removed the userInteractingRef guard from the store→map sync effect; the existing tolerance check (1e-4°) reliably prevents infinite loops since moveend→updateStorePosition sets the store to the map's actual position, which the tolerance check catches on the next effect run

https://claude.ai/code/session_016WjHUUSTuPaFMLkRuPUaXm