### PR TITLE
fix(p1): type handlers Mapbox, clean dead code, fix Resend lazy init

### DIFF
--- a/app/(routes)/view-listing/_components/ProductsTab.tsx
+++ b/app/(routes)/view-listing/_components/ProductsTab.tsx
@@ -289,10 +289,6 @@ export default function ProductsTab({
       if (selectedCategory !== "all" && category.name !== selectedCategory)
         return false;
 
-      if (showSeasonalOnly) {
-        // TODO: filtrer quand tu auras season[] réels
-      }
-
       if (!searchLower) return true;
 
       const categoryMatches = category.name.toLowerCase().includes(searchLower);
@@ -301,7 +297,7 @@ export default function ProductsTab({
       );
       return categoryMatches || itemsMatch;
     });
-  }, [productCategories, selectedCategory, searchTerm, showSeasonalOnly]);
+  }, [productCategories, selectedCategory, searchTerm]);
 
   const categoryNames = useMemo(
     () => productCategories.map((cat) => cat.name),

--- a/app/dashboard/farms/page.tsx
+++ b/app/dashboard/farms/page.tsx
@@ -608,10 +608,8 @@ export default function FarmerDashboard(): JSX.Element {
           </p>
         </div>
 
-        {/* ✅ NOUVEAU — Bannière "Paiements bientôt disponible" MVP
-            À supprimer quand Stripe Connect sera intégré.
-            TODO (Stripe) : supprimer ce bloc une fois l'onboarding
-            Stripe Connect implémenté dans /api/stripe/connect/route.ts */}
+        {/* Bannière MVP — paiements en ligne post-MVP (Stripe Connect)
+            À retirer quand /api/stripe/connect/route.ts sera implémenté. */}
         <div className="mb-6 flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
           <Clock className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
           <div>

--- a/app/modules/maps/components/MapboxClusterLayer.tsx
+++ b/app/modules/maps/components/MapboxClusterLayer.tsx
@@ -168,7 +168,6 @@ function addPointsLayerIfNeeded(map: mapboxgl.Map): void {
         "case",
         ["boolean", ["feature-state", "hover"], false],
         14,
-        // Stage 3 TODO:
         ["boolean", ["feature-state", "selected"], false], 16,
         10,
       ],

--- a/app/modules/maps/components/MapboxSection.tsx
+++ b/app/modules/maps/components/MapboxSection.tsx
@@ -298,8 +298,8 @@ export default function MapboxSection({
         }
       };
 
-      const handleMoveStart = (e?: any) => {
-        if (e?.originalEvent) userInteractingRef.current = true;
+      const handleMoveStart = (e: mapboxgl.MapEventOf<"movestart">) => {
+        if (e.originalEvent) userInteractingRef.current = true;
       };
 
       const handleMoveEnd = () => {
@@ -315,7 +315,7 @@ export default function MapboxSection({
         }
       };
 
-      const handleMapError = (e: any) => {
+      const handleMapError = (e: mapboxgl.ErrorEvent) => {
         console.error("Erreur Mapbox:", e);
         setMapLoading(false);
       };

--- a/lib/config/email-notifications.ts
+++ b/lib/config/email-notifications.ts
@@ -36,9 +36,17 @@ interface EmailResponse {
 }
 
 // =======================
-// Resend client
+// Resend client (lazy — évite le crash au build sans RESEND_API_KEY)
 // =======================
-const resend = new Resend(process.env.RESEND_API_KEY);
+let _resend: Resend | null = null;
+function getResend(): Resend {
+  if (!_resend) {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) throw new Error("RESEND_API_KEY manquant dans les variables d'environnement");
+    _resend = new Resend(key);
+  }
+  return _resend;
+}
 
 // =======================
 // Helpers
@@ -209,7 +217,7 @@ export async function sendAdminNotificationEmail(
         EMAIL_BUILDERS.buildButton("Voir et traiter la demande", adminUrl)
     );
 
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await getResend().emails.send({
       from: EMAIL_CONFIG.fromAddress,
       to: toMutableArray(EMAIL_CONFIG.adminEmails),
       subject: `${EMAIL_SUBJECTS.newFarmerRequest}: ${farmNameSafe}`,
@@ -312,7 +320,7 @@ export async function sendFarmerRequestStatusEmail(
         </div>`
     );
 
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await getResend().emails.send({
       from: EMAIL_CONFIG.fromAddress,
       to: requestData.email, // email brut OK (pas injecté dans HTML)
       subject,


### PR DESCRIPTION
- MapboxSection.tsx: replace `any` handlers with proper Mapbox types (MapEventOf<"movestart"> and ErrorEvent) — no behaviour change
- ProductsTab.tsx: remove empty no-op `if (showSeasonalOnly) {}` block and drop stale `showSeasonalOnly` from useMemo deps (it had no effect)
- MapboxClusterLayer.tsx: remove residual "Stage 3 TODO:" inline comment (the Mapbox expression was already in place and functional)
- dashboard/farms/page.tsx: replace TODO keyword with clear post-MVP label in Stripe payments banner comment
- email-notifications.ts: lazy-init Resend client to fix build crash when RESEND_API_KEY is absent at build time (module-level throw prevented Next.js from collecting page data for the admin producer-requests route)

any types left intentionally (require Listing interface refactor, P2):
  - lib/data/listings.ts: parseListingCoords(listing: any) — Listing.availability is "open"|"closed" but DB enum is French strings; types diverged
  - app/dashboard/farms/page.tsx: normalizeListing(data: any) — same root cause

https://claude.ai/code/session_01PhV1AmfttC19akqHhKyVPv