### PR TITLE
feat: add 🍓 seasonal strawberries filter

### DIFF
--- a/app/_components/layout/FilterSection/FilterSection.tsx
+++ b/app/_components/layout/FilterSection/FilterSection.tsx
@@ -14,7 +14,10 @@ import ActiveFilters from "./components/ActiveFilters";
 import ViewToggle from "./components/ViewToggle";
 import MobileFilters from "./components/MobileFilters";
 
-import { useUnifiedStore } from "@/lib/store/unifiedStore";
+import {
+  useUnifiedStore,
+  useSeasonalStrawberriesOnly,
+} from "@/lib/store/unifiedStore";
 import type { FilterState } from "@/lib/store/unifiedStore";
 
 // ✅ Configuration et utils
@@ -61,6 +64,10 @@ const FilterSection: React.FC<FilterSectionProps> = ({ className = "" }) => {
 
   // ✅ MIGRATION: Sélecteur optimisé du store unifié
   const filters = useUnifiedStore((state) => state.filters.current);
+  const seasonalStrawberriesOnly = useSeasonalStrawberriesOnly();
+  const toggleSeasonalStrawberries = useUnifiedStore(
+    (s) => s.filtersActions.toggleSeasonalStrawberries
+  );
 
   // ═══ Hooks personnalisés ═══
   const {
@@ -264,6 +271,25 @@ const FilterSection: React.FC<FilterSectionProps> = ({ className = "" }) => {
                 )}
               </div>
             </DropdownPill>
+
+            {/* ═══ Filtre Fraises de saison ═══ */}
+            <button
+              type="button"
+              onClick={toggleSeasonalStrawberries}
+              aria-pressed={seasonalStrawberriesOnly}
+              className={`inline-flex h-9 flex-shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-red-400 ${
+                seasonalStrawberriesOnly
+                  ? "border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+                  : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+              }`}
+              aria-label={
+                seasonalStrawberriesOnly
+                  ? "Désactiver le filtre fraises de saison"
+                  : "Filtrer les fermes avec des fraises de saison"
+              }
+            >
+              🍓 Fraises de saison
+            </button>
 
             {/* ═══ Bouton modal filtres avancés ═══ */}
             <button

--- a/app/modules/listings/components/Listing.tsx
+++ b/app/modules/listings/components/Listing.tsx
@@ -50,6 +50,7 @@ interface ListingItem {
   active?: boolean;
   clerk_user_id?: string | null;
   distance?: number | null;
+  hasStrawberriesNow?: boolean;
 }
 
 /**
@@ -450,6 +451,13 @@ const ListItem = React.memo<ListItemProps>(
                   </span>
                 )}
               </div>
+            )}
+
+            {/* Fraises de saison badge */}
+            {item.hasStrawberriesNow && (
+              <span className="inline-flex w-fit items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-600">
+                🍓 Fraises
+              </span>
             )}
 
             {/* Description */}

--- a/lib/data/listings.ts
+++ b/lib/data/listings.ts
@@ -5,6 +5,10 @@ import { supabaseServerPublic } from "@/utils/supabase/server-public";
 import { TABLES, LISTING_COLUMNS } from "@/lib/config";
 import type { Listing } from "@/lib/types";
 import type { Database } from "@/lib/types/database";
+import {
+  hasSeasonalStrawberries,
+  type SeasonalProduct,
+} from "@/lib/utils/seasonality";
 
 export type ListingWithImages =
   Database["public"]["Tables"]["listing"]["Row"] & {
@@ -47,7 +51,8 @@ export async function getLieux(
       `id, name, address, lat, lng, active, clerk_user_id, osm_id, slug,
        availability, product_type, certifications, purchase_mode,
        production_method, additional_services, description,
-       created_at, ${TABLES.LISTING_IMAGES}(id, url)`
+       created_at, ${TABLES.LISTING_IMAGES}(id, url),
+       ${TABLES.PRODUCTS}!listing_id(id, name, seasonal, season_start, season_end)`
     )
     .or("active.eq.true,and(osm_id.not.is.null,clerk_user_id.is.null)")
     .order(LISTING_COLUMNS.CREATED_AT, { ascending: false })
@@ -58,7 +63,14 @@ export async function getLieux(
     return [];
   }
 
-  return (data ?? []).map(parseListingCoords);
+  return (data ?? []).map((row) => {
+    const listing = parseListingCoords(row as Record<string, unknown>);
+    const products = (row as Record<string, unknown>)[TABLES.PRODUCTS];
+    listing.hasStrawberriesNow = hasSeasonalStrawberries(
+      Array.isArray(products) ? (products as SeasonalProduct[]) : null
+    );
+    return listing;
+  });
 }
 
 export const getListing = cache(

--- a/lib/store/shared/types.ts
+++ b/lib/store/shared/types.ts
@@ -53,6 +53,8 @@ export interface Listing {
   distance?: number | null;
   /** Slug URL unique — ex: ferme-dollinger-182 */
   slug?: string;
+  /** true si la ferme propose des fraises actuellement en saison */
+  hasStrawberriesNow?: boolean;
 }
 
 /**

--- a/lib/store/unifiedStore.ts
+++ b/lib/store/unifiedStore.ts
@@ -92,6 +92,7 @@ interface FiltersState {
   current: FilterState;
   applied: FilterState;
   hasActiveFilters: boolean;
+  seasonalStrawberriesOnly: boolean;
 }
 
 /**
@@ -154,6 +155,7 @@ interface FiltersActions {
   resetFilters: () => void;
   toggleFilter: (key: keyof FilterState, value: string) => void;
   applyFilters: () => void;
+  toggleSeasonalStrawberries: () => void;
 }
 
 /**
@@ -314,6 +316,7 @@ export const useUnifiedStore = create<UnifiedStore>()(
           current: EMPTY_FILTERS,
           applied: EMPTY_FILTERS,
           hasActiveFilters: false,
+          seasonalStrawberriesOnly: false,
         },
 
         interactions: {
@@ -522,9 +525,20 @@ export const useUnifiedStore = create<UnifiedStore>()(
                 current: EMPTY_FILTERS,
                 applied: EMPTY_FILTERS,
                 hasActiveFilters: false,
+                seasonalStrawberriesOnly: false,
               },
             }));
             // ✅ Synchronisation automatique après reset
+            get().applyFiltersAndBounds();
+          },
+
+          toggleSeasonalStrawberries: () => {
+            set((state) => ({
+              filters: {
+                ...state.filters,
+                seasonalStrawberriesOnly: !state.filters.seasonalStrawberriesOnly,
+              },
+            }));
             get().applyFiltersAndBounds();
           },
 
@@ -631,13 +645,15 @@ export const useUnifiedStore = create<UnifiedStore>()(
         applyFiltersAndBounds: () => {
           const state = get();
           const { all } = state.listings;
-          const { applied: filters } = state.filters;
+          const { applied: filters, seasonalStrawberriesOnly } = state.filters;
           const { bounds } = state.map;
 
-          // Étape 1: Filtrer par critères de filtre
-          const filtered = all.filter((listing) =>
-            doesListingMatchFilters(listing, filters)
-          );
+          // Étape 1: Filtrer par critères de filtre + filtre fraises de saison
+          const filtered = all.filter((listing) => {
+            if (!doesListingMatchFilters(listing, filters)) return false;
+            if (seasonalStrawberriesOnly && !listing.hasStrawberriesNow) return false;
+            return true;
+          });
 
           // Étape 2: Filtrer par bounds géographiques
           const visible = filtered.filter((listing) =>
@@ -708,6 +724,9 @@ export const useCurrentFilters = () =>
 
 export const useHasActiveFilters = () =>
   useUnifiedStore((state) => state.filters.hasActiveFilters);
+
+export const useSeasonalStrawberriesOnly = () =>
+  useUnifiedStore((state) => state.filters.seasonalStrawberriesOnly);
 
 export const useIsMapExpanded = () =>
   useUnifiedStore((state) => state.ui.isMapExpanded);

--- a/lib/utils/seasonality.ts
+++ b/lib/utils/seasonality.ts
@@ -1,0 +1,43 @@
+// lib/utils/seasonality.ts
+// Logique métier pour les produits de saison — sans logique dans les composants UI.
+
+export interface SeasonalProduct {
+  name: string;
+  seasonal: boolean;
+  season_start: string | null;
+  season_end: string | null;
+}
+
+const STRAWBERRY_PATTERNS = ["fraise", "fraises", "strawberry"];
+
+function isStrawberry(name: string): boolean {
+  const lower = name.toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+  return STRAWBERRY_PATTERNS.some((p) => lower.includes(p));
+}
+
+/**
+ * Retourne true si la liste de produits contient au moins une fraise
+ * actuellement en saison (seasonal + today ∈ [season_start, season_end]).
+ */
+export function hasSeasonalStrawberries(
+  products?: SeasonalProduct[] | null
+): boolean {
+  if (!products?.length) return false;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return products.some((p) => {
+    if (!isStrawberry(p.name)) return false;
+    if (!p.seasonal) return false;
+    if (!p.season_start || !p.season_end) return false;
+
+    const start = new Date(p.season_start);
+    const end = new Date(p.season_end);
+
+    // Guard against invalid dates
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) return false;
+
+    return today >= start && today <= end;
+  });
+}


### PR DESCRIPTION
- lib/utils/seasonality.ts: pure hasSeasonalStrawberries() function handles null products, null dates, case/accents, "strawberry" alias
- lib/data/listings.ts: join products!listing_id at fetch time, compute hasStrawberriesNow boolean once server-side
- lib/store/shared/types.ts: add hasStrawberriesNow to Listing type
- lib/store/unifiedStore.ts: add seasonalStrawberriesOnly to FiltersState, toggleSeasonalStrawberries action, applyFiltersAndBounds applies it
- FilterSection.tsx: 🍓 Fraises de saison chip (toggle ON/OFF)
- Listing.tsx: 🍓 Fraises badge on cards when hasStrawberriesNow

Combiner cleanly with existing filters, zero new deps, no schema changes.

https://claude.ai/code/session_01PsSRJJT3U6dzjxwhcRUQtC